### PR TITLE
xslate file detection fails if .tx file contains html

### DIFF
--- a/ftdetect/xslate.vim
+++ b/ftdetect/xslate.vim
@@ -1,2 +1,2 @@
-autocmd BufNewFile,BufRead *.tx setfiletype xslate
+autocmd BufNewFile,BufRead *.tx set filetype=xslate
 autocmd BufNewFile,BufRead *.html if search('^: ') > 0 | set filetype=xslate | endif


### PR DESCRIPTION
Updated ftdetect to always set filetype to xslate if the file has a .tx extension - previously .tx files were treated as HTML if vim detected HTML content, losing the xslate syntax highlighting
