### PR TITLE
Fix highlighting html in txBlock

### DIFF
--- a/syntax/xslate.vim
+++ b/syntax/xslate.vim
@@ -5,7 +5,7 @@ syntax keyword txKeyword cascade around block override macro contained
 syntax match txKeyword +contains+ contained
 
 syntax include @inlinePerl syntax/perl.vim
-syntax cluster inlinePerl remove=perlFunctionName remove=perlElseIfError
+syntax cluster inlinePerl remove=perlFunctionName remove=perlElseIfError remove=perlBraces
 syntax clear perlElseIfError
 syntax region txBlock   matchgroup=txDelim start=+<:+ end=+:>+ contains=txKeyword,txComment,@inlinePerl containedin=ALL keepend
 syntax match  txBlock   +^\s*:.*$+ contains=txDelim,txKeyword,txComment,@inlinePerl


### PR DESCRIPTION
If html notations are in block of Perl, these are not highlighted certainly.
![https://dl.dropboxusercontent.com/u/14832699/xslate-vim/xslate-vim_old.png](https://dl.dropboxusercontent.com/u/14832699/xslate-vim/xslate-vim_old.png)

So I fixed it;
![https://dl.dropboxusercontent.com/u/14832699/xslate-vim/xslate-vim_new.png](https://dl.dropboxusercontent.com/u/14832699/xslate-vim/xslate-vim_new.png)

How do you feel?
